### PR TITLE
[patch] Upgrade golang version to 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ alias:
   default: &default
     working_directory: /go/src/github.com/yahoojapan/garm
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.16
         environment:
           GOPATH: "/go"
           GO111MODULE: "on"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ make test
 
 ## Dependency management
 
-The Garm project uses [Go modules](https://golang.org/cmd/go/#hdr-Modules__module_versions__and_more) to manage dependencies on external packages. This requires a working Go environment with version 1.14 or greater installed.
+The Garm project uses [Go modules](https://golang.org/cmd/go/#hdr-Modules__module_versions__and_more) to manage dependencies on external packages. This requires a working Go environment with version 1.16 or greater installed.
 
 To add or update a new dependency, use the `go get` command:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine AS base
+FROM golang:1.16-alpine AS base
 
 RUN set -eux \
     && apk update \

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Garm implements the Kubernetes authorization webhook interface to provide access
 
 By default, Garm replies the native Kubernetes authentication for authorization. However, it also supports the Kubernetes authentication webhook. Using the authentication hook requires Athenz to be able to sign tokens for users.
 
-Requires go 1.14 or later.
+Requires go 1.16 or later.
 
 ## Use Case
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yahoojapan/garm
 
-go 1.14
+go 1.16
 
 replace k8s.io/client-go => k8s.io/client-go v0.18.3
 

--- a/main_test.go
+++ b/main_test.go
@@ -113,7 +113,7 @@ func Test_run(t *testing.T) {
 				},
 				checkFunc: func(cfg config.Config) error {
 					got := run(cfg)
-					want := "failed to instantiate daemon: athenz service instantiate failed: athenz timeout parse failed: time: invalid duration dummy"
+					want := `failed to instantiate daemon: athenz service instantiate failed: athenz timeout parse failed: time: invalid duration "dummy"`
 					if len(got) != 1 {
 						return errors.New("len(got) != 1")
 					}
@@ -136,7 +136,7 @@ func Test_run(t *testing.T) {
 				},
 				checkFunc: func(cfg config.Config) error {
 					got := run(cfg)
-					want := "failed to instantiate daemon: token service instantiate failed: invalid token refresh duration dummy: time: invalid duration dummy"
+					want := `failed to instantiate daemon: token service instantiate failed: invalid token refresh duration dummy: time: invalid duration "dummy"`
 					if len(got) != 1 {
 						return errors.New("len(got) != 1")
 					}

--- a/service/athenz_test.go
+++ b/service/athenz_test.go
@@ -199,7 +199,7 @@ func TestNewAthenz(t *testing.T) {
 			name:      "Check NewAthenz fail with nil cfg",
 			args:      args{},
 			want:      nil,
-			wantError: fmt.Errorf("athenz timeout parse failed: time: invalid duration "),
+			wantError: fmt.Errorf("athenz timeout parse failed: %s", `time: invalid duration ""`),
 		},
 		{
 			name: "Check NewAthenz fail with invalid timeout duration",
@@ -209,7 +209,7 @@ func TestNewAthenz(t *testing.T) {
 				},
 			},
 			want:      nil,
-			wantError: fmt.Errorf("athenz timeout parse failed: time: invalid duration %s", "xxxtimeout"),
+			wantError: fmt.Errorf("athenz timeout parse failed: %s", `time: invalid duration "xxxtimeout"`),
 		},
 		{
 			name: "Check NewAthenz fail with unknown timeout unit",
@@ -219,7 +219,7 @@ func TestNewAthenz(t *testing.T) {
 				},
 			},
 			want:      nil,
-			wantError: fmt.Errorf("athenz timeout parse failed: time: unknown unit %s in duration %s", "ss", "10ss"),
+			wantError: fmt.Errorf("athenz timeout parse failed: %s", `time: unknown unit "ss" in duration "10ss"`),
 		},
 		{
 			name: "Check NewAthenz fail with timeout having no units",
@@ -229,7 +229,7 @@ func TestNewAthenz(t *testing.T) {
 				},
 			},
 			want:      nil,
-			wantError: fmt.Errorf("athenz timeout parse failed: time: missing unit in duration %s", "99"),
+			wantError: fmt.Errorf("athenz timeout parse failed: %s", `time: missing unit in duration "99"`),
 		},
 	}
 	errToStr := func(err error) string {

--- a/service/tls_test.go
+++ b/service/tls_test.go
@@ -141,7 +141,7 @@ func TestNewTLSConfig(t *testing.T) {
 					}
 
 					if !match {
-						return fmt.Errorf("CurvePreferences not Find :\twant %s", string(want.MinVersion))
+						return fmt.Errorf("CurvePreferences not Find :\twant %d", want.MinVersion)
 					}
 				}
 				return nil

--- a/service/token_test.go
+++ b/service/token_test.go
@@ -52,7 +52,7 @@ func TestNewTokenService(t *testing.T) {
 					RefreshDuration: "test",
 				},
 			},
-			wantErr: fmt.Errorf("invalid token refresh duration %s: %v", "test", "time: invalid duration test"),
+			wantErr: fmt.Errorf("invalid token refresh duration %s: %v", "test", `time: invalid duration "test"`),
 		},
 		{
 			name: "Test error invalid expiration",
@@ -62,7 +62,7 @@ func TestNewTokenService(t *testing.T) {
 					Expiration:      "test",
 				},
 			},
-			wantErr: fmt.Errorf("invalid token expiration %s: %v", "test", "time: invalid duration test"),
+			wantErr: fmt.Errorf("invalid token expiration %s: %v", "test", `time: invalid duration "test"`),
 		},
 		func() test {
 			keyEnvName := "dummyKey"

--- a/usecase/garmd_test.go
+++ b/usecase/garmd_test.go
@@ -54,7 +54,7 @@ func TestNew(t *testing.T) {
 					Token: config.Token{},
 				},
 			},
-			wantErr: fmt.Errorf("token service instantiate failed: invalid token refresh duration : time: invalid duration "),
+			wantErr: fmt.Errorf(`token service instantiate failed: invalid token refresh duration : time: invalid duration ""`),
 		},
 		func() test {
 			keyEnvName := "dummyKey"
@@ -81,7 +81,7 @@ func TestNew(t *testing.T) {
 				afterFunc: func() {
 					os.Unsetenv(keyEnvName)
 				},
-				wantErr: fmt.Errorf("athenz service instantiate failed: athenz timeout parse failed: time: invalid duration "),
+				wantErr: fmt.Errorf(`athenz service instantiate failed: athenz timeout parse failed: time: invalid duration ""`),
 			}
 		}(),
 		func() test {


### PR DESCRIPTION
## Changes
Upgrade golang version to 1.16

## TODO
1. fix unit test
```
--- FAIL: Test_server_hcShutdown (0.00s)
    --- FAIL: Test_server_hcShutdown/hcShutdown_works (0.00s)
        server_test.go:544: server.listenAndServe() Error = context deadline exceeded
--- FAIL: Test_server_apiShutdown (0.00s)
    --- FAIL: Test_server_apiShutdown/apiShutdown_works (0.00s)
        server_test.go:627: server.listenAndServe() Error = context deadline exceeded
```