### PR TITLE
[patch] prevent crashing from panic

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -54,7 +54,7 @@ func parseTimeout(timeout string) time.Duration {
 	if err != nil {
 		err = glg.Errorf("Invalid timeout value: %s", timeout)
 		if err != nil {
-			glg.Fatal(errors.Wrap(err, "timeout parse error out put failed"))
+			glg.Fatal(errors.Wrap(err, "timeout parse error output failed"))
 		}
 		dur = time.Second * 3
 	}
@@ -103,7 +103,7 @@ func routing(m []string, t time.Duration, h handler.Func) http.Handler {
 								http.StatusInternalServerError)
 							err = glg.Error(err)
 							if err != nil {
-								glg.Fatal(errors.Wrap(err, "handler error out put failed"))
+								glg.Fatal(errors.Wrap(err, "handler error output failed"))
 							}
 						}
 						return
@@ -111,7 +111,7 @@ func routing(m []string, t time.Duration, h handler.Func) http.Handler {
 						// timeout passed or parent context canceled first, it is the responsibility for handler to response to the user
 						err := glg.Errorf("Handler Time Out: %v", time.Since(start))
 						if err != nil {
-							glg.Fatal(errors.Wrap(err, "timeout error out put failed"))
+							glg.Fatal(errors.Wrap(err, "timeout error output failed"))
 						}
 						return
 					}

--- a/router/router.go
+++ b/router/router.go
@@ -83,9 +83,11 @@ func routing(m []string, t time.Duration, h handler.Func) http.Handler {
 							glg.Errorf("recover panic from athenz webhook: %+v", r)
 						}
 					}()
+					defer func() {
+						close(ech)
+					}()
 					// it is the responsibility for handler to close the request
 					ech <- h(w, r.WithContext(ctx))
-					close(ech)
 				}()
 
 				for {

--- a/router/router.go
+++ b/router/router.go
@@ -80,7 +80,10 @@ func routing(m []string, t time.Duration, h handler.Func) http.Handler {
 					defer func() {
 						r := recover()
 						if r != nil {
-							glg.Errorf("recover panic from athenz webhook: %+v", r)
+							err := glg.Errorf("recover panic from athenz webhook: %+v", r)
+							if err != nil {
+								glg.Fatal(errors.Wrap(err, "webhook handler panic output failed"))
+							}
 						}
 					}()
 					defer func() {

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -768,6 +768,44 @@ func Test_recoverWrap(t *testing.T) {
 	tests := []testcase{
 		func() testcase {
 			handlerFunc := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write([]byte("response-body-772"))
+				if err != nil {
+					return
+				}
+			})
+			want := "response-body-772"
+
+			return testcase{
+				name: "Check recoverWrap, success",
+				args: args{
+					h: handlerFunc,
+				},
+				checkFunc: func(server http.Handler) error {
+					request, err := http.NewRequest(http.MethodGet, "/", nil)
+					if err != nil {
+						return err
+					}
+					recorder := httptest.NewRecorder()
+					server.ServeHTTP(recorder, request)
+
+					response := recorder.Result()
+					defer response.Body.Close()
+					gotByte, err := ioutil.ReadAll(response.Body)
+					if err != nil {
+						return err
+					}
+
+					got := string(gotByte)
+					if got != want {
+						return fmt.Errorf("recoverWrap() http.Handler on request %v, response body = %v, want %v", request, got, want)
+					}
+
+					return nil
+				},
+			}
+		}(),
+		func() testcase {
+			handlerFunc := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				_, err := w.Write([]byte("response-body-732"))
 				if err != nil {
 					return

--- a/service/tls.go
+++ b/service/tls.go
@@ -105,7 +105,7 @@ func NewX509CertPool(path string) (*x509.CertPool, error) {
 		if err != nil || pool == nil {
 			err = glg.Error(errors.Wrap(err, "SystemCertPool not found"))
 			if err != nil {
-				return nil, errors.Wrap(err, "timeout parse error out put failed")
+				return nil, errors.Wrap(err, "timeout parse error output failed")
 			}
 			pool = x509.NewCertPool()
 		}


### PR DESCRIPTION
# Description

Prevent garm from crashing due to `panic: Header called after Handler finished`.
This PR does not solve the root cause for `panic: Header called after Handler finished`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] breaks backward compatibility
- [ ] requires a documentation update
- [ ] has untestable code

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[major]`/`[minor]`/`[patch]`/`[skip]` in the PR title
- [x] Tested and linted the code
- [x] Commented the code
- [x] Made corresponding changes to the documentation
- [x] Confirmed no dropping in test coverage (by [Codecov](https://codecov.io/gh/yahoojapan/garm/pulls))
- [x] Passed all pipeline checking
- [x] Approved by >1 reviewer

## Checklist for maintainer
- [x] Use `Squash and merge`
- [x] Double-confirm the merge message has prefix `[major]`/`[minor]`/`[patch]`/`[skip]`
- [x] Delete the branch after merge
